### PR TITLE
Update GPT-5 model dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The app will be available at http://localhost:5200.
 | Name | Description |
 | ---- | ----------- |
 | `REPLICATE_API_TOKEN` | **Required.** Your Replicate API token. |
-| `REPLICATE_DEFAULT_MODEL` | Optional. Default GPT‑5 model id (must be from the dropdown options). |
+| `REPLICATE_DEFAULT_MODEL` | Optional. Default GPT‑5 model id (must match one of `openai/gpt-5.0-mini`, `openai/gpt-5.0`, or `openai/gpt-5.0-pro`). |
 | `MAX_UPLOAD_MB` | Optional. Maximum upload size in MB (default `15`). |
 
 ## Notes

--- a/app.py
+++ b/app.py
@@ -18,8 +18,9 @@ app.config["MAX_CONTENT_LENGTH"] = int(os.getenv("MAX_UPLOAD_MB", "15")) * 1024 
 DEBUG_MODE = os.getenv("FLASK_DEBUG", "0") == "1"
 
 AVAILABLE_MODELS: List[Dict[str, str]] = [
-    {"id": "openai/gpt-5.0-mini", "label": "GPT‑5 Mini"},
-    {"id": "openai/gpt-5.0-large", "label": "GPT‑5 Large"},
+    {"id": "openai/gpt-5.0-mini", "label": "GPT‑5.0 Mini"},
+    {"id": "openai/gpt-5.0", "label": "GPT‑5.0"},
+    {"id": "openai/gpt-5.0-pro", "label": "GPT‑5.0 Pro"},
 ]
 DEFAULT_MODEL = os.getenv("REPLICATE_DEFAULT_MODEL", AVAILABLE_MODELS[0]["id"])
 _client: "replicate.Client | None" = None


### PR DESCRIPTION
## Summary
- replace placeholder GPT-5 dropdown entries with the Replicate GPT-5.0 mini, standard, and pro variants
- document the accepted GPT-5.0 model identifiers for the REPLICATE_DEFAULT_MODEL environment variable

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d565d3fa748333b2796792c10cfa96