### PR TITLE
Switch UI to light theme

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,8 +1,8 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #0f172a;
-  color: #e2e8f0;
+  background-color: #f8fafc;
+  color: #0f172a;
 }
 
 body {
@@ -10,6 +10,7 @@ body {
   padding: 2rem;
   display: flex;
   justify-content: center;
+  background: #f1f5f9;
 }
 
 main {
@@ -26,16 +27,16 @@ header h1 {
 
 .tagline {
   margin-top: 0.3rem;
-  color: #94a3b8;
+  color: #475569;
 }
 
 .panel {
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 16px;
   padding: 1.5rem;
-  backdrop-filter: blur(16px);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
 }
 
 .field {
@@ -54,8 +55,8 @@ select,
 textarea {
   padding: 0.75rem;
   border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(255, 255, 255, 0.9);
   color: inherit;
 }
 
@@ -73,7 +74,7 @@ button,
   border: none;
   border-radius: 999px;
   padding: 0.8rem 1.6rem;
-  background: linear-gradient(120deg, #6366f1, #8b5cf6);
+  background: linear-gradient(120deg, #2563eb, #0ea5e9);
   color: #fff;
   font-weight: 600;
   cursor: pointer;
@@ -95,23 +96,23 @@ button[disabled] {
 .output pre {
   white-space: pre-wrap;
   word-wrap: break-word;
-  background: rgba(15, 23, 42, 0.8);
+  background: rgba(241, 245, 249, 0.9);
   padding: 1rem;
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(15, 23, 42, 0.1);
   max-height: 340px;
   overflow-y: auto;
 }
 
 .metadata {
   font-size: 0.95rem;
-  color: #94a3b8;
+  color: #475569;
 }
 
 .info ol {
   margin: 0;
   padding-left: 1.25rem;
-  color: #cbd5f5;
+  color: #1e293b;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- update global colors and surfaces to use a light palette
- refresh button gradient, metadata text, and panel accents for the new light theme

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5688e9b3c8333969789b032924b15